### PR TITLE
Don't write to JSONL as "a" (append) by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ data = [{"foo": "bar"}, {"baz": 123}]
 srsly.write_jsonl("/path/to/file.jsonl", data)
 ```
 
-| Argument   | Type             | Description                                |
-| ---------- | ---------------- | ------------------------------------------ |
-| `location` | unicode / `Path` | The file path or `"-"` to write to stdout. |
-| `lines`    | iterable         | The JSON-serializable lines.               |
+| Argument   | Type             | Description                                                                                                            |
+| ---------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `location` | unicode / `Path` | The file path or `"-"` to write to stdout.                                                                             |
+| `lines`    | iterable         | The JSON-serializable lines.                                                                                           |
+| `append`   | bool             | Append to an existing file. Will open it in `"a"` mode and insert a newline before writing lines. Defaults to `False`. |
 
 #### <kbd>function</kbd> `srsly.read_jsonl`
 

--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -86,7 +86,7 @@ def read_jsonl(location, skip=False):
                 yield line
 
 
-def write_jsonl(location, lines):
+def write_jsonl(location, lines, append=False):
     """Create a .jsonl file and dump contents or write to standard output.
 
     location (unicode / Path): The file path. "-" for writing to stdout.
@@ -96,8 +96,11 @@ def write_jsonl(location, lines):
         for line in lines:
             print(json_dumps(line))
     else:
+        mode = "a" if append else "w"
         file_path = force_path(location, require_exists=False)
-        with file_path.open("a", encoding="utf-8") as f:
+        with file_path.open(mode, encoding="utf-8") as f:
+            if append:
+                f.write("\n")
             for line in lines:
                 f.write(json_dumps(line) + "\n")
 


### PR DESCRIPTION
Initial report: https://support.prodi.gy/t/1648/6

This PR makes the mode default to `"w"` and adds a boolean argument `append` to `write_jsonl`. If set, it'll also insert newline before writing more lines to prevent invalid JSON.

Disclaimer: If a user chooses to set `append=True`, they're responsible for making sure that their file doesn't include trailing newlines or is empty. Maybe in the future, we can add some more checks here, e.g. peek at the file to see if the previous character is `\n`, if the file is empty etc. and then decide whether to start with a newline or not.