### PR TITLE
Add use_gzip flag for json read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,34 @@ data = srsly.read_json("/path/to/file.json")
 | `location`  | unicode / `Path` | The file path or `"-"` to read from stdin. |
 | **RETURNS** | dict / list      | The loaded JSON content.                   |
 
+#### <kbd>function</kbd> `srsly.write_gzip_json`
+
+Create a gzipped JSON file and dump contents.
+
+```python
+data = {"foo": "bar", "baz": 123}
+srsly.write_gzip_json("/path/to/file.json.gz", data)
+```
+
+| Argument   | Type             | Description                                            |
+| ---------- | ---------------- | ------------------------------------------------------ |
+| `location` | unicode / `Path` | The file path.                                         |
+| `data`     | -                | The JSON-serializable data to output.                  |
+| `indent`   | int              | Number of spaces used to indent JSON. Defaults to `2`. |
+
+#### <kbd>function</kbd> `srsly.read_gzip_json`
+
+Load gzipped JSON from a file.
+
+```python
+data = srsly.read_json("/path/to/file.json.gz")
+```
+
+| Argument    | Type             | Description              |
+| ----------- | ---------------- | ------------------------ |
+| `location`  | unicode / `Path` | The file path.           |
+| **RETURNS** | dict / list      | The loaded JSON content. |
+
 #### <kbd>function</kbd> `srsly.write_jsonl`
 
 Create a JSONL file (newline-delimited JSON) and dump contents line by line, or

--- a/srsly/__init__.py
+++ b/srsly/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-from ._json_api import read_json, write_json, read_jsonl, write_jsonl
+from ._json_api import read_json, read_gzip_json, write_json, write_gzip_json, read_jsonl, write_jsonl
 from ._json_api import json_dumps, json_loads, is_json_serializable
 from ._msgpack_api import read_msgpack, write_msgpack, msgpack_dumps, msgpack_loads
 from ._pickle_api import pickle_dumps, pickle_loads

--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -38,7 +38,7 @@ def json_loads(data):
     return ujson.loads(data)
 
 
-def read_json(location, use_gzip=False):
+def read_json(location):
     """Load JSON from file or standard input.
 
     location (unicode / Path): The file path. "-" for reading from stdin.
@@ -46,19 +46,22 @@ def read_json(location, use_gzip=False):
     """
     if location == "-":  # reading from sys.stdin
         data = sys.stdin.read()
-        if use_gzip:
-            data = gzip.uncompress(data)
         return ujson.loads(data)
     file_path = force_path(location)
-    if use_gzip:
-        with gzip.open(file_path, "r") as f:
-            return ujson.load(f)
-    else:
-        with file_path.open("r", encoding="utf8") as f:
-            return ujson.load(f)
+    with file_path.open("r", encoding="utf8") as f:
+        return ujson.load(f)
 
+def read_gzip_json(location):
+    """Load JSON from a gzipped file.
 
-def write_json(location, data, indent=2, use_gzip=False):
+        location (unicode / Path): The file path.
+        RETURNS (dict / list): The loaded JSON content.
+    """
+    file_path = force_path(location)
+    with gzip.open(file_path, "r") as f:
+        return ujson.load(f)
+
+def write_json(location, data, indent=2):
     """Create a .json file and dump contents or write to standard
     output.
 
@@ -68,19 +71,23 @@ def write_json(location, data, indent=2, use_gzip=False):
     """
     json_data = json_dumps(data, indent=indent)
     if location == "-":  # writing to stdout
-        if use_gzip:
-            print(gzip.compress(json_data.encode('utf-8')))
-        else:
-            print(json_data)
+        print(json_data)
     else:
         file_path = force_path(location, require_exists=False)
-        if use_gzip:
-            with gzip.open(file_path, "w") as f:
-                f.write(json_data.encode('utf-8'))
-        else:
-            with file_path.open("w", encoding="utf8") as f:
-                f.write(json_data)
+        with file_path.open("w", encoding="utf8") as f:
+            f.write(json_data)
 
+def write_gzip_json(location, data, indent=2):
+    """Create a .json.gz file and dump contents.
+
+    location (unicode / Path): The file path.
+    data: The JSON-serializable data to output.
+    indent (int): Number of spaces used to indent JSON.
+    """
+    json_data = json_dumps(data, indent=indent)
+    file_path = force_path(location, require_exists=False)
+    with gzip.open(file_path, "w") as f:
+        f.write(json_data.encode('utf-8'))
 
 def read_jsonl(location, skip=False):
     """Read a .jsonl file or standard input and yield contents line by line.

--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -6,7 +6,7 @@ import json as _builtin_json
 import gzip
 
 from . import ujson
-from .util import force_path
+from .util import force_path, force_string
 
 
 def json_dumps(data, indent=0, sort_keys=False):
@@ -58,7 +58,7 @@ def read_gzip_json(location):
         location (unicode / Path): The file path.
         RETURNS (dict / list): The loaded JSON content.
     """
-    file_path = force_path(location)
+    file_path = force_string(location)
     with gzip.open(file_path, "r") as f:
         return ujson.load(f)
 
@@ -88,7 +88,7 @@ def write_gzip_json(location, data, indent=2):
     indent (int): Number of spaces used to indent JSON.
     """
     json_data = json_dumps(data, indent=indent)
-    file_path = force_path(location, require_exists=False)
+    file_path = force_string(location)
     with gzip.open(file_path, "w") as f:
         f.write(json_data.encode("utf-8"))
 

--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -51,6 +51,7 @@ def read_json(location):
     with file_path.open("r", encoding="utf8") as f:
         return ujson.load(f)
 
+
 def read_gzip_json(location):
     """Load JSON from a gzipped file.
 
@@ -60,6 +61,7 @@ def read_gzip_json(location):
     file_path = force_path(location)
     with gzip.open(file_path, "r") as f:
         return ujson.load(f)
+
 
 def write_json(location, data, indent=2):
     """Create a .json file and dump contents or write to standard
@@ -77,6 +79,7 @@ def write_json(location, data, indent=2):
         with file_path.open("w", encoding="utf8") as f:
             f.write(json_data)
 
+
 def write_gzip_json(location, data, indent=2):
     """Create a .json.gz file and dump contents.
 
@@ -87,7 +90,8 @@ def write_gzip_json(location, data, indent=2):
     json_data = json_dumps(data, indent=indent)
     file_path = force_path(location, require_exists=False)
     with gzip.open(file_path, "w") as f:
-        f.write(json_data.encode('utf-8'))
+        f.write(json_data.encode("utf-8"))
+
 
 def read_jsonl(location, skip=False):
     """Read a .jsonl file or standard input and yield contents line by line.

--- a/srsly/tests/test_json_api.py
+++ b/srsly/tests/test_json_api.py
@@ -71,6 +71,7 @@ def test_write_json_file():
         with Path(file_path).open("r", encoding="utf8") as f:
             assert f.read() in expected
 
+
 def test_write_json_file_gzip():
     data = {"hello": "world", "test": 123}
     # Provide two expected options, depending on how keys are ordered
@@ -83,6 +84,7 @@ def test_write_json_file_gzip():
         write_gzip_json(file_path, data)
         with gzip.open(file_path, "r") as f:
             assert f.read().decode("utf8") in expected
+
 
 def test_write_json_stdout(capsys):
     data = {"hello": "world", "test": 123}

--- a/srsly/tests/test_json_api.py
+++ b/srsly/tests/test_json_api.py
@@ -7,6 +7,7 @@ from io import StringIO
 from pathlib import Path
 from contextlib import contextmanager
 import shutil
+import gzip
 
 from .._json_api import read_json, write_json, read_jsonl, write_jsonl
 from .._json_api import json_dumps, is_json_serializable
@@ -69,6 +70,19 @@ def test_write_json_file():
         write_json(file_path, data)
         with Path(file_path).open("r", encoding="utf8") as f:
             assert f.read() in expected
+
+def test_write_json_file_gzip():
+    data = {"hello": "world", "test": 123}
+    # Provide two expected options, depending on how keys are ordered
+    expected = [
+        '{\n  "hello":"world",\n  "test":123\n}',
+        '{\n  "test":123,\n  "hello":"world"\n}',
+    ]
+    with make_tempdir() as temp_dir:
+        file_path = temp_dir / "tmp.json"
+        write_json(file_path, data, use_gzip=True)
+        with gzip.open(file_path, "r") as f:
+            assert f.read().decode("utf8") in expected
 
 
 def test_write_json_stdout(capsys):

--- a/srsly/tests/test_json_api.py
+++ b/srsly/tests/test_json_api.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import shutil
 import gzip
 
-from .._json_api import read_json, write_json, read_jsonl, write_jsonl
+from .._json_api import read_json, write_json, read_jsonl, write_jsonl, write_gzip_json
 from .._json_api import json_dumps, is_json_serializable
 
 
@@ -80,10 +80,9 @@ def test_write_json_file_gzip():
     ]
     with make_tempdir() as temp_dir:
         file_path = temp_dir / "tmp.json"
-        write_json(file_path, data, use_gzip=True)
+        write_gzip_json(file_path, data)
         with gzip.open(file_path, "r") as f:
             assert f.read().decode("utf8") in expected
-
 
 def test_write_json_stdout(capsys):
     data = {"hello": "world", "test": 123}

--- a/srsly/tests/test_json_api.py
+++ b/srsly/tests/test_json_api.py
@@ -11,6 +11,7 @@ import gzip
 
 from .._json_api import read_json, write_json, read_jsonl, write_jsonl, write_gzip_json
 from .._json_api import json_dumps, is_json_serializable
+from ..util import force_string
 
 
 @contextmanager
@@ -80,7 +81,7 @@ def test_write_json_file_gzip():
         '{\n  "test":123,\n  "hello":"world"\n}',
     ]
     with make_tempdir() as temp_dir:
-        file_path = temp_dir / "tmp.json"
+        file_path = force_string(temp_dir / "tmp.json")
         write_gzip_json(file_path, data)
         with gzip.open(file_path, "r") as f:
             assert f.read().decode("utf8") in expected

--- a/srsly/util.py
+++ b/srsly/util.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from pathlib import Path
+import sys
 
 
 def force_path(location, require_exists=True):
@@ -10,3 +11,9 @@ def force_path(location, require_exists=True):
     if require_exists and not location.exists():
         raise ValueError("Can't read file: {}".format(location))
     return location
+
+
+def force_string(location):
+    if sys.version_info[0] == 2:  # Python 2
+        return str(location).decode("utf8")
+    return str(location)

--- a/srsly/util.py
+++ b/srsly/util.py
@@ -5,6 +5,15 @@ from pathlib import Path
 import sys
 
 
+is_python2 = sys.version_info[0] == 2
+is_python3 = sys.version_info[0] == 3
+
+if is_python2:
+    basestring_ = basestring  # noqa: F821
+else:
+    basestring_ = str
+
+
 def force_path(location, require_exists=True):
     if not isinstance(location, Path):
         location = Path(location)
@@ -14,6 +23,8 @@ def force_path(location, require_exists=True):
 
 
 def force_string(location):
+    if isinstance(location, basestring_):
+        return location
     if sys.version_info[0] == 2:  # Python 2
         return str(location).decode("utf8")
     return str(location)


### PR DESCRIPTION
The basic idea here is to use gzipped json for disk-efficient storage of simply structured data. In particular this should come in handy in shrinking language data in spaCy.

As of this commit this works, and there's a basic test. A couple of things to improve:

- code seems redundant, clean it up
- more tests
- maybe add support to other functions, like the jsonl ones