### PR TITLE
Add jsonl no new line append

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ srsly.write_jsonl("/path/to/file.jsonl", data)
 | `location` | unicode / `Path` | The file path or `"-"` to write to stdout.                                                                             |
 | `lines`    | iterable         | The JSON-serializable lines.                                                                                           |
 | `append`   | bool             | Append to an existing file. Will open it in `"a"` mode and insert a newline before writing lines. Defaults to `False`. |
+| `append_new_line`   | bool             | Defines whether a new line should first be written when appending to an existing file. Defaults to `True`. |
 
 #### <kbd>function</kbd> `srsly.read_jsonl`
 

--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -111,11 +111,14 @@ def read_jsonl(location, skip=False):
                 yield line
 
 
-def write_jsonl(location, lines, append=False):
+def write_jsonl(location, lines, append=False, append_new_line=True):
     """Create a .jsonl file and dump contents or write to standard output.
 
     location (unicode / Path): The file path. "-" for writing to stdout.
     lines (list): The JSON-serializable contents of each line.
+    append (bool): Whether or not to append to the location.
+    append_new_line (bool): Whether or not to write a new line before appending
+                            to the file.
     """
     if location == "-":  # writing to stdout
         for line in lines:
@@ -124,7 +127,7 @@ def write_jsonl(location, lines, append=False):
         mode = "a" if append else "w"
         file_path = force_path(location, require_exists=False)
         with file_path.open(mode, encoding="utf-8") as f:
-            if append:
+            if append and append_new_line:
                 f.write("\n")
             for line in lines:
                 f.write(json_dumps(line) + "\n")

--- a/srsly/tests/test_json_api.py
+++ b/srsly/tests/test_json_api.py
@@ -151,6 +151,26 @@ def test_write_jsonl_file():
             assert f.read() == '{"hello":"world"}\n{"test":123}\n'
 
 
+def test_write_jsonl_file_append():
+    data = [{"hello": "world"}, {"test": 123}]
+    with make_tempdir() as temp_dir:
+        file_path = temp_dir / "tmp.json"
+        write_jsonl(file_path, data)
+        write_jsonl(file_path, data, append=True)
+        with Path(file_path).open("r", encoding="utf8") as f:
+            assert f.read() == '{"hello":"world"}\n{"test":123}\n\n{"hello":"world"}\n{"test":123}\n'
+
+def test_write_jsonl_file_append_no_new_line():
+    data = [{"hello": "world"}, {"test": 123}]
+    with make_tempdir() as temp_dir:
+        file_path = temp_dir / "tmp.json"
+        write_jsonl(file_path, data)
+        write_jsonl(file_path, data, append=True, append_new_line=False)
+        with Path(file_path).open("r", encoding="utf8") as f:
+            assert f.read() == '{"hello":"world"}\n{"test":123}\n{"hello":"world"}\n{"test":123}\n'
+
+
+
 def test_write_jsonl_stdout(capsys):
     data = [{"hello": "world"}, {"test": 123}]
     write_jsonl("-", data)


### PR DESCRIPTION
Hi,

This is a PR for #13 

This should provide a way to specify whether or not you want a new line appended to the file when using write_jsonl. The current behaviour will be maintained as default.

Please let me know if there are any further improvements that can be made.