### PR TITLE
Remove unsafe YAML implementations, raising if called

### DIFF
--- a/srsly/ruamel_yaml/constructor.py
+++ b/srsly/ruamel_yaml/constructor.py
@@ -828,235 +828,51 @@ if PY2:
 
 class Constructor(SafeConstructor):
     def construct_python_str(self, node):
-        # type: (Any) -> Any
-        return utf8(self.construct_scalar(node))
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_unicode(self, node):
-        # type: (Any) -> Any
-        return self.construct_scalar(node)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     if PY3:
 
         def construct_python_bytes(self, node):
-            # type: (Any) -> Any
-            try:
-                value = self.construct_scalar(node).encode("ascii")
-            except UnicodeEncodeError as exc:
-                raise ConstructorError(
-                    None,
-                    None,
-                    "failed to convert base64 data into ascii: %s" % exc,
-                    node.start_mark,
-                )
-            try:
-                if hasattr(base64, "decodebytes"):
-                    return base64.decodebytes(value)
-                else:
-                    return base64.decodestring(value)
-            except binascii.Error as exc:
-                raise ConstructorError(
-                    None,
-                    None,
-                    "failed to decode base64 data: %s" % exc,
-                    node.start_mark,
-                )
+            raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_long(self, node):
-        # type: (Any) -> int
-        val = self.construct_yaml_int(node)
-        if PY3:
-            return val
-        return int(val)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_complex(self, node):
-        # type: (Any) -> Any
-        return complex(self.construct_scalar(node))
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_tuple(self, node):
-        # type: (Any) -> Any
-        return tuple(self.construct_sequence(node))
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def find_python_module(self, name, mark):
-        # type: (Any, Any) -> Any
-        if not name:
-            raise ConstructorError(
-                "while constructing a Python module",
-                mark,
-                "expected non-empty name appended to the tag",
-                mark,
-            )
-        try:
-            __import__(name)
-        except ImportError as exc:
-            raise ConstructorError(
-                "while constructing a Python module",
-                mark,
-                "cannot find module %r (%s)" % (utf8(name), exc),
-                mark,
-            )
-        return sys.modules[name]
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def find_python_name(self, name, mark):
-        # type: (Any, Any) -> Any
-        if not name:
-            raise ConstructorError(
-                "while constructing a Python object",
-                mark,
-                "expected non-empty name appended to the tag",
-                mark,
-            )
-        if u"." in name:
-            lname = name.split(".")
-            lmodule_name = lname
-            lobject_name = []  # type: List[Any]
-            while len(lmodule_name) > 1:
-                lobject_name.insert(0, lmodule_name.pop())
-                module_name = ".".join(lmodule_name)
-                try:
-                    __import__(module_name)
-                    # object_name = '.'.join(object_name)
-                    break
-                except ImportError:
-                    continue
-        else:
-            module_name = builtins_module
-            lobject_name = [name]
-        try:
-            __import__(module_name)
-        except ImportError as exc:
-            raise ConstructorError(
-                "while constructing a Python object",
-                mark,
-                "cannot find module %r (%s)" % (utf8(module_name), exc),
-                mark,
-            )
-        module = sys.modules[module_name]
-        object_name = ".".join(lobject_name)
-        obj = module
-        while lobject_name:
-            if not hasattr(obj, lobject_name[0]):
-
-                raise ConstructorError(
-                    "while constructing a Python object",
-                    mark,
-                    "cannot find %r in the module %r"
-                    % (utf8(object_name), module.__name__),
-                    mark,
-                )
-            obj = getattr(obj, lobject_name.pop(0))
-        return obj
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_name(self, suffix, node):
-        # type: (Any, Any) -> Any
-        value = self.construct_scalar(node)
-        if value:
-            raise ConstructorError(
-                "while constructing a Python name",
-                node.start_mark,
-                "expected the empty value, but found %r" % utf8(value),
-                node.start_mark,
-            )
-        return self.find_python_name(suffix, node.start_mark)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_module(self, suffix, node):
-        # type: (Any, Any) -> Any
-        value = self.construct_scalar(node)
-        if value:
-            raise ConstructorError(
-                "while constructing a Python module",
-                node.start_mark,
-                "expected the empty value, but found %r" % utf8(value),
-                node.start_mark,
-            )
-        return self.find_python_module(suffix, node.start_mark)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def make_python_instance(self, suffix, node, args=None, kwds=None, newobj=False):
-        # type: (Any, Any, Any, Any, bool) -> Any
-        if not args:
-            args = []
-        if not kwds:
-            kwds = {}
-        cls = self.find_python_name(suffix, node.start_mark)
-        if PY3:
-            if newobj and isinstance(cls, type):
-                return cls.__new__(cls, *args, **kwds)
-            else:
-                return cls(*args, **kwds)
-        else:
-            if newobj and isinstance(cls, type(classobj)) and not args and not kwds:
-                instance = classobj()
-                instance.__class__ = cls
-                return instance
-            elif newobj and isinstance(cls, type):
-                return cls.__new__(cls, *args, **kwds)
-            else:
-                return cls(*args, **kwds)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def set_python_instance_state(self, instance, state):
-        # type: (Any, Any) -> None
-        if hasattr(instance, "__setstate__"):
-            instance.__setstate__(state)
-        else:
-            slotstate = {}  # type: Dict[Any, Any]
-            if isinstance(state, tuple) and len(state) == 2:
-                state, slotstate = state
-            if hasattr(instance, "__dict__"):
-                instance.__dict__.update(state)
-            elif state:
-                slotstate.update(state)
-            for key, value in slotstate.items():
-                setattr(instance, key, value)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_object(self, suffix, node):
-        # type: (Any, Any) -> Any
-        # Format:
-        #   !!python/object:module.name { ... state ... }
-        instance = self.make_python_instance(suffix, node, newobj=True)
-        self.recursive_objects[node] = instance
-        yield instance
-        deep = hasattr(instance, "__setstate__")
-        state = self.construct_mapping(node, deep=deep)
-        self.set_python_instance_state(instance, state)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_object_apply(self, suffix, node, newobj=False):
-        # type: (Any, Any, bool) -> Any
-        # Format:
-        #   !!python/object/apply       # (or !!python/object/new)
-        #   args: [ ... arguments ... ]
-        #   kwds: { ... keywords ... }
-        #   state: ... state ...
-        #   listitems: [ ... listitems ... ]
-        #   dictitems: { ... dictitems ... }
-        # or short format:
-        #   !!python/object/apply [ ... arguments ... ]
-        # The difference between !!python/object/apply and !!python/object/new
-        # is how an object is created, check make_python_instance for details.
-        if isinstance(node, SequenceNode):
-            args = self.construct_sequence(node, deep=True)
-            kwds = {}  # type: Dict[Any, Any]
-            state = {}  # type: Dict[Any, Any]
-            listitems = []  # type: List[Any]
-            dictitems = {}  # type: Dict[Any, Any]
-        else:
-            value = self.construct_mapping(node, deep=True)
-            args = value.get("args", [])
-            kwds = value.get("kwds", {})
-            state = value.get("state", {})
-            listitems = value.get("listitems", [])
-            dictitems = value.get("dictitems", {})
-        instance = self.make_python_instance(suffix, node, args, kwds, newobj)
-        if bool(state):
-            self.set_python_instance_state(instance, state)
-        if bool(listitems):
-            instance.extend(listitems)
-        if bool(dictitems):
-            for key in dictitems:
-                instance[key] = dictitems[key]
-        return instance
+        raise ValueError("Unsafe constructor not implemented in this library")
 
     def construct_python_object_new(self, suffix, node):
-        # type: (Any, Any) -> Any
-        return self.construct_python_object_apply(suffix, node, newobj=True)
+        raise ValueError("Unsafe constructor not implemented in this library")
 
 
 Constructor.add_constructor(

--- a/srsly/ruamel_yaml/loader.py
+++ b/srsly/ruamel_yaml/loader.py
@@ -46,13 +46,7 @@ class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, VersionedRe
 
 class Loader(Reader, Scanner, Parser, Composer, Constructor, VersionedResolver):
     def __init__(self, stream, version=None, preserve_quotes=None):
-        # type: (StreamTextType, Optional[VersionType], Optional[bool]) -> None
-        Reader.__init__(self, stream, loader=self)
-        Scanner.__init__(self, loader=self)
-        Parser.__init__(self, loader=self)
-        Composer.__init__(self, loader=self)
-        Constructor.__init__(self, loader=self)
-        VersionedResolver.__init__(self, version, loader=self)
+        raise ValueError("Unsafe loader not implemented in this library.")
 
 
 class RoundTripLoader(

--- a/srsly/tests/ruamel_yaml/test_add_xxx.py
+++ b/srsly/tests/ruamel_yaml/test_add_xxx.py
@@ -29,22 +29,24 @@ def test_dice_constructor():
     import srsly.ruamel_yaml  # NOQA
 
     srsly.ruamel_yaml.add_constructor(u"!dice", dice_constructor)
-    data = srsly.ruamel_yaml.load(
-        "initial hit points: !dice 8d4", Loader=srsly.ruamel_yaml.Loader
-    )
-    assert str(data) == "{'initial hit points': Dice(8,4)}"
+    with pytest.raises(ValueError):
+        data = srsly.ruamel_yaml.load(
+            "initial hit points: !dice 8d4", Loader=srsly.ruamel_yaml.Loader
+        )
+        assert str(data) == "{'initial hit points': Dice(8,4)}"
 
 
 def test_dice_constructor_with_loader():
     import srsly.ruamel_yaml  # NOQA
 
-    srsly.ruamel_yaml.add_constructor(
-        u"!dice", dice_constructor, Loader=srsly.ruamel_yaml.Loader
-    )
-    data = srsly.ruamel_yaml.load(
-        "initial hit points: !dice 8d4", Loader=srsly.ruamel_yaml.Loader
-    )
-    assert str(data) == "{'initial hit points': Dice(8,4)}"
+    with pytest.raises(ValueError):
+        srsly.ruamel_yaml.add_constructor(
+            u"!dice", dice_constructor, Loader=srsly.ruamel_yaml.Loader
+        )
+        data = srsly.ruamel_yaml.load(
+            "initial hit points: !dice 8d4", Loader=srsly.ruamel_yaml.Loader
+        )
+        assert str(data) == "{'initial hit points': Dice(8,4)}"
 
 
 def test_dice_representer():
@@ -62,14 +64,15 @@ def test_dice_implicit_resolver():
     import srsly.ruamel_yaml  # NOQA
 
     pattern = re.compile(r"^\d+d\d+$")
-    srsly.ruamel_yaml.add_implicit_resolver(u"!dice", pattern)
-    assert (
-        srsly.ruamel_yaml.dump(dict(treasure=Dice(10, 20)), default_flow_style=False)
-        == "treasure: 10d20\n"
-    )
-    assert srsly.ruamel_yaml.load(
-        "damage: 5d10", Loader=srsly.ruamel_yaml.Loader
-    ) == dict(damage=Dice(5, 10))
+    with pytest.raises(ValueError):
+        srsly.ruamel_yaml.add_implicit_resolver(u"!dice", pattern)
+        assert (
+            srsly.ruamel_yaml.dump(dict(treasure=Dice(10, 20)), default_flow_style=False)
+            == "treasure: 10d20\n"
+        )
+        assert srsly.ruamel_yaml.load(
+            "damage: 5d10", Loader=srsly.ruamel_yaml.Loader
+        ) == dict(damage=Dice(5, 10))
 
 
 class Obj1(dict):
@@ -111,9 +114,10 @@ def test_yaml_obj():
 
     srsly.ruamel_yaml.add_representer(Obj1, YAMLObj1.to_yaml)
     srsly.ruamel_yaml.add_multi_constructor(YAMLObj1.yaml_tag, YAMLObj1.from_yaml)
-    x = srsly.ruamel_yaml.load("!obj:x.2\na: 1", Loader=srsly.ruamel_yaml.Loader)
-    print(x)
-    assert srsly.ruamel_yaml.dump(x) == """!obj:x.2 "{'a': 1}"\n"""
+    with pytest.raises(ValueError):
+        x = srsly.ruamel_yaml.load("!obj:x.2\na: 1", Loader=srsly.ruamel_yaml.Loader)
+        print(x)
+        assert srsly.ruamel_yaml.dump(x) == """!obj:x.2 "{'a': 1}"\n"""
 
 
 def test_yaml_obj_with_loader_and_dumper():
@@ -125,10 +129,11 @@ def test_yaml_obj_with_loader_and_dumper():
     srsly.ruamel_yaml.add_multi_constructor(
         YAMLObj1.yaml_tag, YAMLObj1.from_yaml, Loader=srsly.ruamel_yaml.Loader
     )
-    x = srsly.ruamel_yaml.load("!obj:x.2\na: 1", Loader=srsly.ruamel_yaml.Loader)
-    # x = srsly.ruamel_yaml.load('!obj:x.2\na: 1')
-    print(x)
-    assert srsly.ruamel_yaml.dump(x) == """!obj:x.2 "{'a': 1}"\n"""
+    with pytest.raises(ValueError):
+        x = srsly.ruamel_yaml.load("!obj:x.2\na: 1", Loader=srsly.ruamel_yaml.Loader)
+        # x = srsly.ruamel_yaml.load('!obj:x.2\na: 1')
+        print(x)
+        assert srsly.ruamel_yaml.dump(x) == """!obj:x.2 "{'a': 1}"\n"""
 
 
 # ToDo use nullege to search add_multi_representer and add_path_resolver

--- a/srsly/tests/ruamel_yaml/test_issues.py
+++ b/srsly/tests/ruamel_yaml/test_issues.py
@@ -322,7 +322,7 @@ class TestIssues:
         d = yaml.load(yaml_str)
         print(d)
         '''
-        assert save_and_run(dedent(program_src), tmpdir, optimized=True) == 1
+        assert save_and_run(dedent(program_src), tmpdir, optimized=True) == 0
 
     def test_issue_221_add(self):
         from srsly.ruamel_yaml.comments import CommentedSeq

--- a/srsly/tests/ruamel_yaml/test_issues.py
+++ b/srsly/tests/ruamel_yaml/test_issues.py
@@ -83,7 +83,7 @@ class TestIssues:
         for idx, l in enumerate([1, 2, 3, 10000, 100000000000]):
             assert int(ret[idx]) == l
         '''
-        assert save_and_run(dedent(program_src), tmpdir) == 0
+        assert save_and_run(dedent(program_src), tmpdir) == 1
 
     def test_issue_82rt(self, tmpdir):
         yaml_str = "[1, 2, 3, !si 10k, 100G]\n"
@@ -322,7 +322,7 @@ class TestIssues:
         d = yaml.load(yaml_str)
         print(d)
         '''
-        assert save_and_run(dedent(program_src), tmpdir, optimized=True) == 0
+        assert save_and_run(dedent(program_src), tmpdir, optimized=True) == 1
 
     def test_issue_221_add(self):
         from srsly.ruamel_yaml.comments import CommentedSeq
@@ -542,7 +542,7 @@ class TestIssues:
         data = yaml.load(buf.getvalue())
         assert data.x.y[0] == data.x
         """
-        assert save_and_run(dedent(program_src), tmpdir) == 0
+        assert save_and_run(dedent(program_src), tmpdir) == 1
 
     def test_issue_239(self):
         inp = """

--- a/srsly/tests/ruamel_yaml/test_yamlobject.py
+++ b/srsly/tests/ruamel_yaml/test_yamlobject.py
@@ -42,7 +42,7 @@ def test_monster(tmpdir):
         name: Cave spider
     """)
     '''
-    assert save_and_run(program_src, tmpdir) == 0
+    assert save_and_run(program_src, tmpdir) == 1
 
 
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="no __qualname__")
@@ -66,7 +66,7 @@ def test_qualified_name00(tmpdir):
     x = yaml.load(res)
     assert x == A.f
     """
-    assert save_and_run(program_src, tmpdir) == 0
+    assert save_and_run(program_src, tmpdir) == 1
 
 
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="no __qualname__")
@@ -76,14 +76,15 @@ def test_qualified_name01(tmpdir):
     import srsly.ruamel_yaml.comments
     from srsly.ruamel_yaml.compat import StringIO
 
-    yaml = YAML(typ="unsafe", pure=True)
-    yaml.explicit_end = True
-    buf = StringIO()
-    yaml.dump(srsly.ruamel_yaml.comments.CommentedBase.yaml_anchor, buf)
-    res = buf.getvalue()
-    assert (
-        res
-        == "!!python/name:srsly.ruamel_yaml.comments.CommentedBase.yaml_anchor ''\n...\n"
-    )
-    x = yaml.load(res)
-    assert x == srsly.ruamel_yaml.comments.CommentedBase.yaml_anchor
+    with pytest.raises(ValueError):
+        yaml = YAML(typ="unsafe", pure=True)
+        yaml.explicit_end = True
+        buf = StringIO()
+        yaml.dump(srsly.ruamel_yaml.comments.CommentedBase.yaml_anchor, buf)
+        res = buf.getvalue()
+        assert (
+            res
+            == "!!python/name:srsly.ruamel_yaml.comments.CommentedBase.yaml_anchor ''\n...\n"
+        )
+        x = yaml.load(res)
+        assert x == srsly.ruamel_yaml.comments.CommentedBase.yaml_anchor


### PR DESCRIPTION
YAML libraries provide a dangerous API that allows remote code execution, as they allow serialization of Python objects via Pickle.

While we're calling the `safe_load` APIs correctly, it's better to just remove the implementation of the unsafe features entirely, especially since the Ruamel codebase features extremely deceptive conditional logic based on its crazy class hierarchies (e.g. `Constructor` is a subclass of `SafeConstructor`, while `SafeLoader` is not a subclass of `BaseLoader`).

I'm not sure whether `RoundTripConstructor` should be removed too. It's used all through the tests, so it would be difficult. I've at least removed the method bodies of `Loader` and `Constructor`, raising errors if they're ever hit.