### PR TITLE
Testing versions and pins

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,15 @@ jobs:
       Python36Mac:
         imageName: 'macos-10.14'
         python.version: '3.6'
+      Python37Linux:
+        imageName: 'ubuntu-16.04'
+        python.version: '3.7'
+      Python37Windows:
+        imageName: 'vs2017-win2016'
+        python.version: '3.7'
+      Python37Mac:
+        imageName: 'macos-10.14'
+        python.version: '3.7'
       Python38Linux:
         imageName: 'ubuntu-16.04'
         python.version: '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Development requirements
 cython>=0.29.1,<0.30.0
-pytest>=4.0.0,<5.0.0
+pytest>=4.0.0,<7.0.0
 pytest-timeout>=1.3.3,<2.0.0
 mock>=2.0.0,<3.0.0
 numpy>=1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Development requirements
 cython>=0.29.1,<0.30.0
-pytest>=4.0.0,<7.0.0
+pytest>=4.6.5
 pytest-timeout>=1.3.3,<2.0.0
 mock>=2.0.0,<3.0.0
 numpy>=1.15.0


### PR DESCRIPTION
We probably want to extend the upper pin for `pytest`, but I ran into problems with YAML tests failing for me locally with python 3.7 but not python 3.8, so I wanted to run the same tests in the CI.