### PR TITLE
Add consistency test & fix #55

### DIFF
--- a/srsly/_yaml_api.py
+++ b/srsly/_yaml_api.py
@@ -46,6 +46,7 @@ def yaml_dumps(
     sort_keys (bool): Sort dictionary keys.
     RETURNS (str): The serialized string.
     """
+    yaml = CustomYaml()
     yaml.sort_base_mapping_type_on_output = sort_keys
     yaml.indent(mapping=indent_mapping, sequence=indent_sequence, offset=indent_offset)
     return yaml.dump(data)

--- a/srsly/tests/test_yaml_api.py
+++ b/srsly/tests/test_yaml_api.py
@@ -83,7 +83,10 @@ def test_write_yaml_stdout(capsys):
         ({"a": "b", "c": 123}, True),
         ("hello", True),
         (lambda x: x, False),
+        ({"a": lambda x: x}, False),
     ],
 )
 def test_is_yaml_serializable(obj, expected):
+    assert is_yaml_serializable(obj) == expected
+    # Check again to be sure it's consistent
     assert is_yaml_serializable(obj) == expected


### PR DESCRIPTION
This adds a simple test for #55 and fixes it so the test works. However
this is kind of a crude bludgeon fix and may have bad performance
characteristics if there's lots of calls to dump (though that seems
unlikely in practice).