### PR TITLE
Fix typing for JSONInput and JSONInputBin

### DIFF
--- a/srsly/util.py
+++ b/srsly/util.py
@@ -10,8 +10,8 @@ FilePath = Union[str, Path]
 JSONOutput = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 JSONOutputBin = Union[bytes, str, int, float, bool, None, Dict[str, Any], List[Any]]
 # For input, we also accept tuples, ordered dicts etc.
-JSONInput = Union[str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any], OrderedDict]
-JSONInputBin = Union[bytes, str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any], OrderedDict]
+JSONInput = Union[str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any, ...], OrderedDict]
+JSONInputBin = Union[bytes, str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any, ...], OrderedDict]
 YAMLInput = JSONInput
 YAMLOutput = JSONOutput
 # fmt: on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Change `Tuple[Any]` to `Tuple[Any, ...]` for `JSONInput` and `JSONInputBin`. Otherwise type hinting will complain about passing tuples: `srsly.json_dumps(data=(1, 2, 3))` will trigger a type hint warning. 

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.