### PR TITLE
Fix Typing for `JSONOutput` and `JSONOutputBin`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
   strategy:
     matrix:
       Python36Linux:
-        imageName: 'ubuntu-latest'
+        imageName: 'ubuntu-20.04'
         python.version: '3.6'
       Python36Windows:
         imageName: 'windows-2019'

--- a/srsly/util.py
+++ b/srsly/util.py
@@ -7,8 +7,8 @@ from collections import OrderedDict
 FilePath = Union[str, Path]
 # Superficial JSON input/output types
 # https://github.com/python/typing/issues/182#issuecomment-186684288
-JSONOutput = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
-JSONOutputBin = Union[bytes, str, int, float, bool, None, Dict[str, Any], List[Any]]
+JSONOutput = Union[str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any, ...]]
+JSONOutputBin = Union[bytes, str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any, ...]]
 # For input, we also accept tuples, ordered dicts etc.
 JSONInput = Union[str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any, ...], OrderedDict]
 JSONInputBin = Union[bytes, str, int, float, bool, None, Dict[str, Any], List[Any], Tuple[Any, ...], OrderedDict]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Add `Tuple[Any, ...]` for `JSONOutput` and `JSONOutputBin`. Otherwise type hinting will indicate mismatching types if tuples are an expected type, e.g. for `values: Tuple[Any, ...] = srsly.load(value)`.

Also fixes CI image for Linux with Python 3.6.

Related to https://github.com/explosion/srsly/pull/79.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.