### PR TITLE
Add gzipped jsonl reader

### DIFF
--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -111,6 +111,18 @@ def read_jsonl(path: FilePath, skip: bool = False) -> Iterable[JSONOutput]:
             for line in _yield_json_lines(f, skip=skip):
                 yield line
 
+def read_gzip_jsonl(path: FilePath, skip: bool = False) -> Iterable[JSONOutput]:
+    """Read a gzipped .jsonl file and yield contents line by line.
+    Blank lines will always be skipped.
+    
+    path (FilePath): The file path.
+    skip (bool): Skip broken lines and don't raise ValueError.
+    YIELDS (JSONOutput): The loaded JSON contents of each line.
+    """
+    file_path = force_path(path)
+    with gzip.open(file_path, "r") as f:
+        for line in _yield_juson_lines(f, skip=skip)
+            yield line
 
 def write_jsonl(
     path: FilePath,


### PR DESCRIPTION
Add a simple modification to the jsonl reader that unzips a file. If the API instead of just allowing a path also allowed to pass in a file stream I could have handled it outside of this, but this seems the most straightforward solutions atm.