### PR TITLE
Missing jsonl import

### DIFF
--- a/srsly/__init__.py
+++ b/srsly/__init__.py
@@ -1,4 +1,4 @@
-from ._json_api import read_json, read_gzip_json, write_json, write_gzip_json
+from ._json_api import read_json, read_gzip_json, write_json, write_gzip_json, write_gzip_jsonl
 from ._json_api import read_jsonl, write_jsonl
 from ._json_api import json_dumps, json_loads, is_json_serializable
 from ._msgpack_api import read_msgpack, write_msgpack, msgpack_dumps, msgpack_loads

--- a/srsly/__init__.py
+++ b/srsly/__init__.py
@@ -1,10 +1,5 @@
-from ._json_api import (
-    read_json,
-    read_gzip_json,
-    write_json,
-    write_gzip_json,
-    write_gzip_jsonl,
-)
+from ._json_api import read_json, read_gzip_json, write_json, write_gzip_json
+from ._json_api import read_gzip_jsonl, write_gzip_jsonl
 from ._json_api import read_jsonl, write_jsonl
 from ._json_api import json_dumps, json_loads, is_json_serializable
 from ._msgpack_api import read_msgpack, write_msgpack, msgpack_dumps, msgpack_loads

--- a/srsly/__init__.py
+++ b/srsly/__init__.py
@@ -1,4 +1,10 @@
-from ._json_api import read_json, read_gzip_json, write_json, write_gzip_json, write_gzip_jsonl
+from ._json_api import (
+    read_json,
+    read_gzip_json,
+    write_json,
+    write_gzip_json,
+    write_gzip_jsonl,
+)
 from ._json_api import read_jsonl, write_jsonl
 from ._json_api import json_dumps, json_loads, is_json_serializable
 from ._msgpack_api import read_msgpack, write_msgpack, msgpack_dumps, msgpack_loads


### PR DESCRIPTION
I noticed the docs mentioned `write_gzip_jsonl` but I wasn't able to import it. 

Then I noticed that it was implemented but missing from `__init__.py`. Hence a PR.