### PR TITLE
Feature/typed json api

### DIFF
--- a/srsly/_json_api.py
+++ b/srsly/_json_api.py
@@ -91,15 +91,25 @@ def read_json_dict(path: FilePath) -> Dict[str, Any]:
     return data
 
 
-def read_json_list(path: FilePath) -> List[Dict[str, Any]]:
+def read_json_list(path: FilePath, validate_inner: bool = False, skip_invalid: bool = False) -> List[Dict[str, Any]]:
     """Load JSON from file or standard input.
 
     path (FilePath): The file path. "-" for reading from stdin.
     RETURNS (JSONOutput): The loaded JSON content.
     """
+
     data = read_json(path)
+    err_msg = "Invalid JSON, data could not be parsed to a list of dicts."
     if not isinstance(data, list):
-        raise ValueError("Invalid JSON, data could not be parsed to a list of dicts.")
+        raise ValueError(err_msg)
+
+    output = []
+    for i, obj in enumerate(data):
+        if not isinstance(obj, dict):
+            if skip_invalid:
+                continue
+            raise ValueError(f"Invalid JSON Object at index: {i + 1}. Value is not a valid dict.")
+        output.append(obj)
     return data
 
 

--- a/srsly/tests/test_json_api.py
+++ b/srsly/tests/test_json_api.py
@@ -4,8 +4,13 @@ from pathlib import Path
 import gzip
 import numpy
 
+from typing import Any, Dict, List, Union
+
 from .._json_api import (
     read_json,
+    read_json_dict,
+    read_json_list,
+    read_jsonl_dicts,
     write_json,
     read_jsonl,
     write_jsonl,
@@ -262,3 +267,40 @@ def test_read_jsonl_gzip():
     assert len(data[1]) == 1
     assert data[0]["hello"] == "world"
     assert data[1]["test"] == 123
+
+
+READ_JSON_DICT_TEST_CASES = {
+
+}
+
+
+READ_JSONL_DICT_TEST_CASES = {
+    "invalid_str": ('"test"', ValueError()),
+    "invalid_num": ('-32', ValueError()),
+    "invalid_json_list": ('[{"hello": "world"}\n{"test": 123}]', ValueError()),
+    "valid_dicts": ('{"hello": "world"}\n{"test": 123}', [{"hello": "world"}, {"test": 123}]),
+}
+
+@pytest.mark.parametrize(
+    "file_contents, expected",
+    READ_JSONL_DICT_TEST_CASES.values(),
+    ids=READ_JSONL_DICT_TEST_CASES.keys()
+)
+def test_read_jsonl_dicts(file_contents: str, expected: Union[List[Dict[str, Any]], ValueError]):
+
+    with make_tempdir({"tmp.json": file_contents}) as temp_dir:
+        file_path = temp_dir / "tmp.json"
+        assert file_path.exists()
+        data = read_jsonl_dicts(file_path)
+        # Make sure this returns a generator, not just a list
+        assert not hasattr(data, "__len__")
+        try:
+            # actually consume the generator to trigger errors
+            data = list(data)
+        except ValueError:
+            assert isinstance(expected, ValueError)
+        else:
+            assert isinstance(expected, list)
+            assert len(data) == len(expected)
+            for data_item, expected_item in zip(data, expected):
+                assert data_item == expected_item


### PR DESCRIPTION
## Context


Currently most loader functions use the `JSONOutput` return type. This type is pretty non specific and a bit hard to reason about downstream. I find myself having to cast or validate the resulting type all the time.

The current loaders return `JSONOutput` because this file e.g. is valid JSON and would be parsed properly by `ujson` 

`test_file.json` 
```json
hello
```

However, if we get this JSON file as an input in most of our code paths, we would want to raise an error as this is almost certainly invalid for what we want to do next.

This PR adds validation on top of the existing JSON API to ensure you get the expected type from a loader function.

If we like this approach, I can add to the rest of the API, just implementing the most commonly used functions from the JSON API for now.

## Summary of Changes

Add `read_json_dict` - read JSON file and validate the resulting object is a `dict`
Add `read_json_list` - read JSON file and validate the resulting object is a `list` of `dict`s
Add `read_jsonl_dicts` - read JSONL file and validate each line is a valid `dict` in the resulting generator