### PR TITLE
Restrict to cython 0.29.x in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
     "setuptools",
-    "cython>=0.25",
+    "cython>=0.29.1,<0.30.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ zip_safe = true
 include_package_data = true
 python_requires = >=3.6
 setup_requires =
-    cython>=0.25
+    cython>=0.29.1,<0.30.0
 install_requires =
     catalogue>=2.0.3,<2.1.0
 


### PR DESCRIPTION
Update `pyproject.toml` to correspond to `requirements.txt`.

`srsly` v2 does not work out of the box with cython 3 due to errors related to typedefs in msgpack and I couldn't immediately find a solution that was compatible with both cython 0.29 and cython 3, so this is patch on our side until we can find a solution or appropriate upstream patch.