### PR TITLE
Fix path coercion for pathlib-like interfaces (Pathy)

### DIFF
--- a/srsly/util.py
+++ b/srsly/util.py
@@ -18,7 +18,7 @@ YAMLOutput = JSONOutput
 
 
 def force_path(location, require_exists=True):
-    if not isinstance(location, Path):
+    if isinstance(location, str):
         location = Path(location)
     if require_exists and not location.exists():
         raise ValueError(f"Can't read file: {location}")


### PR DESCRIPTION
Pathy inherited from `pathlib.Path`, so this always worked for saving spaCy models, but a new Pathy version that supports Python 3.12 will not inherit from `pathlib.Path` so this check fails and model saving goes with it.

[Someone pointed out](https://github.com/justindujardin/pathy/issues/105#issuecomment-1885689212) that the spaCy contributing doc specifies how things should work. 

> Code that interacts with the file-system should accept objects that follow the pathlib.Path API, without assuming that the object inherits from pathlib.Path. If the function is user-facing and takes a path as an argument, it should check whether the path is provided as a string. Strings should be converted to pathlib.Path objects. 

I don't know if that extends to srsly, but I would think so.

There's more context on the Pathy 3.12 issue: https://github.com/justindujardin/pathy/issues/106#issuecomment-1885500685