### PR TITLE
use newer unittest.mock from the standard library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ catalogue>=2.0.3,<2.1.0
 cython>=0.29.1,<0.30.0
 pytest>=4.6.5
 pytest-timeout>=1.3.3
-mock>=2.0.0,<3.0.0
 numpy>=1.15.0
 psutil

--- a/srsly/tests/test_msgpack_api.py
+++ b/srsly/tests/test_msgpack_api.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 import datetime
-from mock import patch
+from unittest.mock import patch
 import numpy
 
 from .._msgpack_api import read_msgpack, write_msgpack


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.