### PR TITLE
Refresh CI to a sane  point

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,12 +1,18 @@
-name: Build
+name: Build wheels
 
 on:
   push:
-    tags:
-      # ytf did they invent their own syntax that's almost regex?
-      # ** matches 'zero or more of any character'
-      - 'release-v[0-9]+.[0-9]+.[0-9]+**'
-      - 'prerelease-v[0-9]+.[0-9]+.[0-9]+**'
+    branches: [master]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch: # allows you to trigger manually
+
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: Build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     uses: explosion/gha-cibuildwheel/.github/workflows/cibuildwheel.yml@main
@@ -16,6 +22,6 @@ jobs:
     with:
       wheel-name-pattern: "srsly-*.whl"
       pure-python: false
+      create-release: ${{ startsWith(github.ref, 'refs/tags/release-') || startsWith(github.ref, 'refs/tags/prerelease-') }}
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        # FIXME: ujson segfault on 3.14
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,39 +1,37 @@
-name: tests
+name: Test
 
 on:
   push:
-    tags-ignore:
-      - '**'
-    paths-ignore:
-      - "*.md"
-      - ".github/cibuildwheel.yml"
-      - ".github/publish_pypi.yml"
+    branches: [master]
   pull_request:
-    types: [opened, synchronize, reopened, edited]
-    paths-ignore:
-      - "*.md"
-      - ".github/cibuildwheel.yml"
-      - ".github/publish_pypi.yml"
+    branches: ["*"]
+  workflow_dispatch: # allows you to trigger manually
+
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: Test-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MODULE_NAME: 'srsly'
   RUN_MYPY: 'false'
 
 jobs:
   tests:
-    name: Test
-    if: github.repository_owner == 'explosion'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
       - name: Configure Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "*"
-skip = ["cp38*", "cp314t-*"]
+skip = [
+    "cp38*",   # Obsolete
+    "cp314-*",  # FIXME ujson segfaults
+    "cp314t-*",  # TODO free-threading support (note: 3.13t is skipped by default)
+]
 test-skip = ""
 
 archs = ["native"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
 requires = [
     "setuptools",
-    "cython>=0.25",
+    "cython>=0.29.1",
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "*"
-skip = "cp38*"
+skip = ["cp38*", "cp314t-*"]
 test-skip = ""
 
 archs = ["native"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,13 +22,13 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
     Topic :: Scientific/Engineering
 
 [options]
 zip_safe = true
 include_package_data = true
-python_requires = >=3.9,<3.15
+# FIXME ujson segfaults on 3.14
+python_requires = >=3.9,<3.14
 setup_requires =
     cython>=0.29.1
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Scientific/Engineering
 
 [options]

--- a/srsly/tests/cloudpickle/cloudpickle_test.py
+++ b/srsly/tests/cloudpickle/cloudpickle_test.py
@@ -112,7 +112,11 @@ def test_extract_class_dict():
             return "c"
 
     clsdict = _extract_class_dict(C)
-    assert sorted(clsdict.keys()) == ["C_CONSTANT", "__doc__", "method_c"]
+    if sys.version_info >= (3, 13):
+        expected_keys = ["C_CONSTANT", "__doc__", "__firstlineno__", "method_c"]
+    else:
+        expected_keys = ["C_CONSTANT", "__doc__", "method_c"]
+    assert sorted(clsdict.keys()) == expected_keys
     assert clsdict["C_CONSTANT"] == 43
     assert clsdict["__doc__"] is None
     assert clsdict["method_c"](C()) == C().method_c()

--- a/srsly/tests/cloudpickle/cloudpickle_test.py
+++ b/srsly/tests/cloudpickle/cloudpickle_test.py
@@ -116,7 +116,7 @@ def test_extract_class_dict():
         expected_keys = ["C_CONSTANT", "__doc__", "__firstlineno__", "method_c"]
     else:
         expected_keys = ["C_CONSTANT", "__doc__", "method_c"]
-    assert sorted(clsdict.keys()) == expected_keys
+    assert sorted(clsdict) == expected_keys
     assert clsdict["C_CONSTANT"] == 43
     assert clsdict["__doc__"] is None
     assert clsdict["method_c"](C()) == C().method_c()


### PR DESCRIPTION
- Run wheels and tests on all PRs
- Run CI on 3.13. Fix trivial test failure for cloudpickle on 3.13.
- Temporarily disable 3.14, which causes this very old fork of ujson to segfault as demonstrated by https://github.com/explosion/srsly/pull/117